### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-detectable
+*.markdown linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

SCSS 47.2%
HTML 38.9%
Ruby 13.9%

After this change, repository gets detected as:

Markdown 50.8%
SCSS 25.8%
HTML 21.3%
Ruby 2.1%

This change was added for a cosmetic effect on GitHub. It might be
good to go away once this repository is no longer hosted at GitHub, or
if GitHub ceases to use the line, or GitHub ceases to exist.