### PR TITLE
Fix broken link

### DIFF
--- a/about.md
+++ b/about.md
@@ -5,7 +5,7 @@ permalink: /about/
 tags: about
 ---
 
-This is a community blog for the [Lightning Network](lightninganetwork)
+This is a community blog for the [Lightning Network](//lightning.network)
 operated by Lightning Labs. This blog will track the latest developments in the
 Lightning Network specifications, software releases, community integration, and
 new Layer 2 applications.


### PR DESCRIPTION
Before this change: https://lightning.community/about/ (at the time of writing).

After this change (example): https://katesalazar.github.io/lightninglabs.github.io/about/ (at the time of writing).
